### PR TITLE
Fix out of bounds/null pointer access

### DIFF
--- a/plugins/src/amxinfo.cpp
+++ b/plugins/src/amxinfo.cpp
@@ -96,7 +96,7 @@ void amx::register_natives(AMX *amx, const AMX_NATIVE_INFO *nativelist, int numb
 {
 	const auto &obj = load_lock(amx);
 	auto &natives = obj->get_extra<natives_extra>().natives;
-	for(int i = 0; nativelist[i].name != nullptr && (i < number || number == -1); i++)
+	for(int i = 0; (i < number || number == -1) && nativelist[i].name != nullptr; i++)
 	{
 		natives.insert(std::make_pair(nativelist[i].name, nativelist[i].func));
 	}


### PR DESCRIPTION
One correct use of using amx_Register is to pass an array and the native count, instead of "terminating" the array with a null object.

https://github.com/IllidanS4/PawnPlus/blob/19c59e2ceb86021f5659724e3ee77395f0e746c5/plugins/src/amxinfo.cpp#L99

There's already a check for the count, but it's done too late since the code tries to access an OOB slot. 
There's also a case where the AMX runtime will pass null as the native list and 0 as count:

https://github.com/pawn-lang/compiler/blob/68b326814c35f07ae3b1e36bd8014ee0a78b920a/source/amx/amx.c#L3089

In that case, the count check is done too late as the code tries to access a null pointer.