### PR TITLE
Add handler_inverted_return for callback handlers

### DIFF
--- a/pawno/include/PawnPlus.inc
+++ b/pawno/include/PawnPlus.inc
@@ -207,6 +207,7 @@ enum handler_flags
     handler_default = 0,
     handler_return = 1,
     handler_args = 2,
+    handler_inverted_return = 4,
 }
 
 const Guard:INVALID_GUARD = Guard:0;

--- a/plugins/src/modules/events.cpp
+++ b/plugins/src/modules/events.cpp
@@ -350,6 +350,17 @@ bool event_info::invoke(AMX *amx, cell *retval, cell id)
 
 		handled = 0;
 		err = amx_Exec(amx, &handled, index);
+		if(flags & 4)
+		{
+			if (handled < 0)
+			{
+				handled = ~handled;
+			}
+			else
+			{
+				handled = 0;
+			}
+		}
 		if(handled || !(flags & 2))
 		{
 			guard.paramcount = amx->paramcount;


### PR DESCRIPTION
This handler checks if the return value is negative. If it is, it inverts the result and returns that as the return value, and other callbacks handlers and the base callback are not executed. This is behavior is identical to the one of y_hooks from YSI.

I want this so I can use it alongside [AGraber/pawn-plus-hooks](https://github.com/AGraber/pawn-plus-hooks), so that it can be functionally identical to y_hooks but leveraging PawnPlus to implement it.